### PR TITLE
feat(ffi_interface): Expose verifier call, add update_sparse_commitment

### DIFF
--- a/banderwagon/src/element.rs
+++ b/banderwagon/src/element.rs
@@ -248,6 +248,8 @@ mod tests {
 
 #[cfg(test)]
 mod test {
+    
+
     use super::*;
     // Two torsion point, *not*  point at infinity {0,-1,0,1}
     fn two_torsion() -> EdwardsProjective {
@@ -264,6 +266,7 @@ mod test {
         [p1, p2]
     }
 
+    #[warn(clippy::needless_range_loop)]
     #[test]
     fn fixed_test_vectors() {
         let expected_bit_string = [
@@ -287,9 +290,9 @@ mod test {
 
         let mut points = vec![];
         let mut point = Element::prime_subgroup_generator();
-        for i in 0..16 {
-            let byts = hex::encode(&point.to_bytes());
-            assert_eq!(byts, expected_bit_string[i], "index {} does not match", i);
+        for i in expected_bit_string.into_iter() {
+            let byts = hex::encode(point.to_bytes());
+            assert_eq!(byts, i, "index {} does not match", i);
 
             points.push(point);
             point = Element(point.0.double())
@@ -330,7 +333,7 @@ mod test {
         let element1 = Element(res);
         let bytes1 = element1.to_bytes();
 
-        if let Some(_) = Element::from_bytes(&bytes1) {
+        if Element::from_bytes(&bytes1).is_some() {
             panic!("point contains a point at infinity and should not have passed deserialization")
         }
     }

--- a/banderwagon/src/element.rs
+++ b/banderwagon/src/element.rs
@@ -248,7 +248,6 @@ mod tests {
 
 #[cfg(test)]
 mod test {
-    
 
     use super::*;
     // Two torsion point, *not*  point at infinity {0,-1,0,1}

--- a/ffi_interface/src/interop.rs
+++ b/ffi_interface/src/interop.rs
@@ -61,7 +61,7 @@ pub fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit
     // Each 32-be-bytes are interpreted as field elements.
     let mut scalars: Vec<banderwagon::Fr> = Vec::with_capacity(n_scalars);
     for b in inp.chunks(32) {
-        scalars.push(Fr::from_be_bytes_mod_order(b));
+        scalars.push(Fr::from_le_bytes_mod_order(b));
     }
 
     // Committing all values at once.
@@ -97,18 +97,18 @@ pub fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit
         )
     }
 
-    // Each 32-be-bytes are interpreted as field elements.
+    // Each 32-le-bytes are interpreted as field elements.
     let mut scalars: Vec<Fr> = Vec::with_capacity(n_scalars);
     for b in inp.chunks(32) {
-        scalars.push(Fr::from_be_bytes_mod_order(b));
+        scalars.push(Fr::from_le_bytes_mod_order(b));
     }
 
     // Committing all values at once.
     let bases = CRS::default();
     let commit = multi_scalar_mul(&bases.G, &scalars);
 
-    // Serializing using first affine coordinate
-    let commit_bytes = commit.to_bytes();
+    // Uncompressed serialization
+    let commit_bytes = commit.to_bytes_uncompressed();
 
     commit_bytes.to_vec()
 }

--- a/ffi_interface/src/interop.rs
+++ b/ffi_interface/src/interop.rs
@@ -61,7 +61,7 @@ pub fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit
     // Each 32-le-bytes are interpreted as field elements.
     let mut scalars: Vec<banderwagon::Fr> = Vec::with_capacity(n_scalars);
     for b in inp.chunks(32) {
-        scalars.push(Fr::from_le_bytes_mod_order(b));
+        scalars.push(Fr::from_be_bytes_mod_order(b));
     }
 
     // Committing all values at once.
@@ -74,6 +74,7 @@ pub fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit
     scalar
         .serialize_compressed(&mut scalar_bytes[..])
         .expect("could not serialise Fr into a 32 byte array");
+    scalar_bytes.reverse();
 
     scalar_bytes.to_vec()
 }
@@ -99,7 +100,7 @@ pub fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit
     // Each 32-le-bytes are interpreted as field elements.
     let mut scalars: Vec<Fr> = Vec::with_capacity(n_scalars);
     for b in inp.chunks(32) {
-        scalars.push(Fr::from_le_bytes_mod_order(b));
+        scalars.push(Fr::from_be_bytes_mod_order(b));
     }
 
     // Committing all values at once.
@@ -156,6 +157,7 @@ mod test {
                 let val = Fr::from((i + 1) as u128);
                 fr_to_le_bytes(-val)
             })
+            .flatten()
             .collect();
 
         let scalars_be: Vec<_> = (0..256)
@@ -200,6 +202,7 @@ mod test {
                 arr.reverse();
                 arr
             })
+            .flatten()
             .collect();
 
         let expected_hash =

--- a/ffi_interface/src/interop.rs
+++ b/ffi_interface/src/interop.rs
@@ -58,7 +58,7 @@ pub fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit
         )
     }
 
-    // Each 32-be-bytes are interpreted as field elements.
+    // Each 32-le-bytes are interpreted as field elements.
     let mut scalars: Vec<banderwagon::Fr> = Vec::with_capacity(n_scalars);
     for b in inp.chunks(32) {
         scalars.push(Fr::from_le_bytes_mod_order(b));
@@ -74,7 +74,6 @@ pub fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit
     scalar
         .serialize_compressed(&mut scalar_bytes[..])
         .expect("could not serialise Fr into a 32 byte array");
-    scalar_bytes.reverse();
 
     scalar_bytes.to_vec()
 }
@@ -123,7 +122,7 @@ pub(crate) fn group_to_field(point: &Element) -> Fr {
 mod test {
     use super::Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_pedersenHash;
     use crate::{
-        commit_to_scalars, deprecated_serialize_commitment, fr_to_be_bytes, hash_commitment,
+        commit_to_scalars, deprecated_serialize_commitment, fr_to_le_bytes, hash_commitment,
         interop::{
             Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commit,
             Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commitRoot,
@@ -152,7 +151,7 @@ mod test {
         let scalars: Vec<_> = (0..256)
             .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
-                fr_to_be_bytes(-val)
+                fr_to_le_bytes(-val)
             })
             .collect();
 
@@ -172,7 +171,7 @@ mod test {
         let scalars: Vec<_> = (0..256)
             .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
-                fr_to_be_bytes(-val)
+                fr_to_le_bytes(-val)
             })
             .collect();
 

--- a/ffi_interface/src/interop.rs
+++ b/ffi_interface/src/interop.rs
@@ -150,11 +150,10 @@ mod test {
     #[test]
     fn interop_commit() {
         let scalars: Vec<_> = (0..256)
-            .map(|i| {
+            .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
                 fr_to_be_bytes(-val)
             })
-            .flatten()
             .collect();
 
         let expected_hash =
@@ -171,11 +170,10 @@ mod test {
     #[test]
     fn interop_commit_root() {
         let scalars: Vec<_> = (0..256)
-            .map(|i| {
+            .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
                 fr_to_be_bytes(-val)
             })
-            .flatten()
             .collect();
 
         let expected_hash =

--- a/ffi_interface/src/lib.rs
+++ b/ffi_interface/src/lib.rs
@@ -5,14 +5,12 @@
 // Once the java jni crate uses the below implementation, we will remove this file.
 pub mod interop;
 
-
-
 use banderwagon::Fr;
 use banderwagon::{trait_defs::*, Element};
 use ipa_multipoint::committer::{Committer, DefaultCommitter};
 use ipa_multipoint::crs::CRS;
 use ipa_multipoint::lagrange_basis::{LagrangeBasis, PrecomputedWeights};
-use ipa_multipoint::multiproof::{MultiPoint, ProverQuery, VerifierQuery, MultiPointProof};
+use ipa_multipoint::multiproof::{MultiPoint, MultiPointProof, ProverQuery, VerifierQuery};
 use ipa_multipoint::transcript::Transcript;
 
 /// A serialized uncompressed group element
@@ -106,7 +104,6 @@ pub fn update_commitment(
     // (w-v)G
     let delta_commitment = committer.scalar_mul(delta, commitment_index as usize);
 
-
     // If commitment is empty, then we are creating a new commitment.
     if old_commitment_bytes == [0u8; 64] {
         Ok(delta_commitment.to_bytes_uncompressed())
@@ -115,9 +112,7 @@ pub fn update_commitment(
         // vG + (w-v)G
         Ok((delta_commitment + old_commitment).to_bytes_uncompressed())
     }
-
 }
-
 
 /// Update commitment for sparse vector.
 pub fn update_commitment_sparse(
@@ -133,14 +128,11 @@ pub fn update_commitment_sparse(
     let mut delta_values: Vec<(Fr, usize)> = Vec::new();
 
     // For each index in commitment_index, we compute the delta value.
-    for index in
-        0..commitment_index_vec.len()
-    {
+    for index in 0..commitment_index_vec.len() {
         let old_scalar = fr_from_le_bytes(&old_scalar_bytes_vec[index]).unwrap();
         let new_scalar = fr_from_le_bytes(&new_scalar_bytes_vec[index]).unwrap();
 
-
-        let tuple = (new_scalar-old_scalar, commitment_index_vec[index]);
+        let tuple = (new_scalar - old_scalar, commitment_index_vec[index]);
 
         delta_values.push(tuple);
     }
@@ -148,8 +140,6 @@ pub fn update_commitment_sparse(
     let delta_commitment = committer.commit_sparse(delta_values);
     Ok((delta_commitment + old_commitment).to_bytes_uncompressed())
 }
-
-
 
 /// Hashes a commitment
 ///
@@ -215,7 +205,6 @@ fn fr_to_le_bytes(fr: banderwagon::Fr) -> [u8; 32] {
     bytes
 }
 
-
 fn fr_from_le_bytes(bytes: &[u8]) -> Result<banderwagon::Fr, Error> {
     let bytes = bytes.to_vec();
     banderwagon::Fr::deserialize_compressed(&bytes[..]).map_err(|_| {
@@ -234,7 +223,11 @@ fn fr_from_le_bytes(bytes: &[u8]) -> Result<banderwagon::Fr, Error> {
 ///
 /// This function assumes that the domain is always 256 values and commitment is 64bytes.
 /// TODO: Test this function.
-pub fn create_proof(precomputed_weights: &mut PrecomputedWeights, transcript: &mut Transcript, input: Vec<u8>) -> Vec<u8> {
+pub fn create_proof(
+    precomputed_weights: &mut PrecomputedWeights,
+    transcript: &mut Transcript,
+    input: Vec<u8>,
+) -> Vec<u8> {
     // Define the chunk size (8289 bytes)
     // C_i, f_i(X), z_i, y_i
     // 64, 8192, 1, 32
@@ -299,8 +292,11 @@ pub fn create_proof(precomputed_weights: &mut PrecomputedWeights, transcript: &m
 /// Proof is verified or not.
 /// TODO: Test this function.
 #[allow(dead_code)]
-fn exposed_verify_call(precomputed_weights: &mut PrecomputedWeights, transcript: &mut Transcript, input: Vec<u8>) -> bool {
-
+fn exposed_verify_call(
+    precomputed_weights: &mut PrecomputedWeights,
+    transcript: &mut Transcript,
+    input: Vec<u8>,
+) -> bool {
     // Proof bytes are 576 bytes
     // First 32 bytes is the g_x_comm_bytes
     // Next 544 bytes are part of IPA proof.
@@ -315,11 +311,9 @@ fn exposed_verify_call(precomputed_weights: &mut PrecomputedWeights, transcript:
     // Create an iterator over the input Vec<u8>
     let chunked_data = verifier_queries.chunks(chunk_size);
 
-
     let mut verifier_queries: Vec<VerifierQuery> = Vec::new();
 
     for chunk in chunked_data.into_iter() {
-
         // We are expecting uncompressed 64 byte commitment (c_i)
         let mut chunk_exact_size: [u8; 64] = [0u8; 64];
         chunk_exact_size.copy_from_slice(&chunk[0..64]);
@@ -342,20 +336,18 @@ fn exposed_verify_call(precomputed_weights: &mut PrecomputedWeights, transcript:
 
     let crs = CRS::default();
 
-    
     proof.check(&crs, precomputed_weights, &verifier_queries, transcript)
 }
-
 
 #[cfg(test)]
 mod tests {
     use std::vec;
 
+    use banderwagon::Fr;
     use ipa_multipoint::{
         committer::{Committer, DefaultCommitter},
         crs::CRS,
     };
-    use banderwagon::Fr;
 
     use crate::{fr_from_be_bytes, fr_to_be_bytes, fr_to_le_bytes};
     #[test]
@@ -414,11 +406,9 @@ mod tests {
 
         let val_indices: Vec<(Fr, usize)> = vec![(a_1, 1), (a_2, 2)];
 
-
         let new_commitment = commitment + committer.commit_sparse(val_indices);
 
         assert_eq!(naive_update, new_commitment);
-
 
         let commitment_index_vec = vec![1, 2];
 
@@ -434,7 +424,6 @@ mod tests {
             new_scalar_bytes_vec,
         )
         .unwrap();
-
 
         assert_eq!(updated_commitment, naive_update.to_bytes_uncompressed());
     }

--- a/ffi_interface/src/lib.rs
+++ b/ffi_interface/src/lib.rs
@@ -111,6 +111,39 @@ pub fn update_commitment(
     Ok((delta_commitment + old_commitment).to_bytes_uncompressed())
 }
 
+
+/// Update commitment for sparse vector.
+pub fn update_commitment_sparse(
+    committer: &DefaultCommitter,
+    old_commitment_bytes: CommitmentBytes,
+    // There can only be at most 256 elements in a verkle branch
+    commitment_index: Vec<usize>,
+    old_scalar_bytes: Vec<ScalarBytes>,
+    new_scalar_bytes: Vec<ScalarBytes>,
+) -> Result<CommitmentBytes, Error> {
+    let old_commitment = Element::from_bytes_unchecked_uncompressed(old_commitment_bytes);
+
+    let mut delta_values: Vec<(Fr, usize)> = Vec::new();
+
+    for index in
+        commitment_index.iter()
+    {
+
+        let old_scalar = fr_from_le_bytes(&old_scalar_bytes[*index as usize]).unwrap();
+        let new_scalar = fr_from_le_bytes(&new_scalar_bytes[*index as usize]).unwrap();
+
+
+        let tuple = (new_scalar-old_scalar, commitment_index[*index as usize].clone());
+
+        delta_values.push(tuple);
+    }
+
+    let delta_commitment = committer.commit_sparse(delta_values);
+    Ok((delta_commitment + old_commitment).to_bytes_uncompressed())
+}
+
+
+
 /// Hashes a commitment
 ///
 /// Note: This commitment can be used as the `commitment root`

--- a/ffi_interface/src/lib.rs
+++ b/ffi_interface/src/lib.rs
@@ -137,6 +137,11 @@ pub fn update_commitment_sparse(
     }
 
     let delta_commitment = committer.commit_sparse(delta_values);
+
+    // If commitment is empty, then we are creating a new commitment.
+    if old_commitment_bytes == [0u8; 64] {
+        return Ok(delta_commitment.to_bytes_uncompressed());
+    }
     Ok((delta_commitment + old_commitment).to_bytes_uncompressed())
 }
 

--- a/verkle-trie/benches/benchmarks/util.rs
+++ b/verkle-trie/benches/benchmarks/util.rs
@@ -23,7 +23,7 @@ pub fn generate_set_of_keys(n: u32) -> impl Iterator<Item = [u8; 32]> {
         hasher.update(&arr[..]);
         hasher.update(b"seed");
 
-        let res: [u8; 32] = hasher.finalize().try_into().unwrap();
+        let res: [u8; 32] = hasher.finalize().into();
         res
     })
 }
@@ -33,7 +33,7 @@ pub fn generate_diff_set_of_keys(n: u32) -> impl Iterator<Item = [u8; 32]> {
         let mut hasher = Sha256::new();
         hasher.update(i.to_be_bytes());
 
-        let res: [u8; 32] = hasher.finalize().try_into().unwrap();
+        let res: [u8; 32] = hasher.finalize().into();
         res
     })
 }

--- a/verkle-trie/tests/trie_fuzzer.rs
+++ b/verkle-trie/tests/trie_fuzzer.rs
@@ -142,7 +142,7 @@ impl BasicPRNG {
         let mut hasher = sha2::Sha256::new();
         hasher.update(&self.counter.to_le_bytes()[..]);
         hasher.update(&self.seed[..]);
-        let res: [u8; 32] = hasher.finalize().try_into().unwrap();
+        let res: [u8; 32] = hasher.finalize().into();
 
         self.counter += 1;
 


### PR DESCRIPTION
- created a verifier call (testing is todo, along with the create_proof method)
- created a method for update_commitment_sparse which will be useful for updating multiple values in one commitment (not only 1 and not 256) - along with small test