### PR TITLE
feat(ffi_interface): add update_commitment_sparse and clippy fixes

### DIFF
--- a/banderwagon/src/element.rs
+++ b/banderwagon/src/element.rs
@@ -287,8 +287,8 @@ mod test {
 
         let mut points = vec![];
         let mut point = Element::prime_subgroup_generator();
-        for i in 0..16 {
-            let byts = hex::encode(&point.to_bytes());
+        for (i, _) in expected_bit_string.into_iter().enumerate() {
+            let byts = hex::encode(point.to_bytes());
             assert_eq!(byts, expected_bit_string[i], "index {} does not match", i);
 
             points.push(point);
@@ -330,7 +330,7 @@ mod test {
         let element1 = Element(res);
         let bytes1 = element1.to_bytes();
 
-        if let Some(_) = Element::from_bytes(&bytes1) {
+        if Element::from_bytes(&bytes1).is_some() {
             panic!("point contains a point at infinity and should not have passed deserialization")
         }
     }

--- a/ffi_interface/src/interop.rs
+++ b/ffi_interface/src/interop.rs
@@ -153,21 +153,19 @@ mod test {
     #[test]
     fn interop_commit() {
         let scalars_le: Vec<_> = (0..256)
-            .map(|i| {
+            .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
                 fr_to_le_bytes(-val)
             })
-            .flatten()
             .collect();
 
         let scalars_be: Vec<_> = (0..256)
-            .map(|i| {
+            .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
                 let mut arr = fr_to_le_bytes(-val);
                 arr.reverse();
                 arr
             })
-            .flatten()
             .collect();
 
         // The previous implementation will return the hash in big endian format
@@ -188,21 +186,19 @@ mod test {
     #[test]
     fn interop_commit_root() {
         let scalars_le: Vec<_> = (0..256)
-            .map(|i| {
+            .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
                 fr_to_le_bytes(-val)
             })
-            .flatten()
             .collect();
 
         let scalars_be: Vec<_> = (0..256)
-            .map(|i| {
+            .flat_map(|i| {
                 let val = Fr::from((i + 1) as u128);
                 let mut arr = fr_to_le_bytes(-val);
                 arr.reverse();
                 arr
             })
-            .flatten()
             .collect();
 
         let expected_hash =

--- a/verkle-trie/benches/benchmarks/util.rs
+++ b/verkle-trie/benches/benchmarks/util.rs
@@ -23,7 +23,7 @@ pub fn generate_set_of_keys(n: u32) -> impl Iterator<Item = [u8; 32]> {
         hasher.update(&arr[..]);
         hasher.update(b"seed");
 
-        let res: [u8; 32] = hasher.finalize().try_into().unwrap();
+        let res: [u8; 32] = hasher.finalize().into();
         res
     })
 }
@@ -33,7 +33,7 @@ pub fn generate_diff_set_of_keys(n: u32) -> impl Iterator<Item = [u8; 32]> {
         let mut hasher = Sha256::new();
         hasher.update(i.to_be_bytes());
 
-        let res: [u8; 32] = hasher.finalize().try_into().unwrap();
+        let res: [u8; 32] = hasher.finalize().into();
         res
     })
 }

--- a/verkle-trie/tests/trie_fuzzer.rs
+++ b/verkle-trie/tests/trie_fuzzer.rs
@@ -142,7 +142,7 @@ impl BasicPRNG {
         let mut hasher = sha2::Sha256::new();
         hasher.update(&self.counter.to_le_bytes()[..]);
         hasher.update(&self.seed[..]);
-        let res: [u8; 32] = hasher.finalize().try_into().unwrap();
+        let res: [u8; 32] = hasher.finalize().into();
 
         self.counter += 1;
 


### PR DESCRIPTION
Adding a way to sparsely update existing commitment with a small test. Also, some clippy recommendations