### PR TITLE
chore!: Remove `deprecated_serialize_commitment` from API

### DIFF
--- a/ffi_interface/src/lib.rs
+++ b/ffi_interface/src/lib.rs
@@ -2,9 +2,8 @@ mod serialization;
 
 // TODO: These are re-exported to not break the java code
 // TODO: we ideally don't want to export these.
-// - deprecated_serialize_commitment will be deprecated
 // - deserialize_update_commitment_sparse should not be exported and is an abstraction leak
-pub use serialization::{deprecated_serialize_commitment, deserialize_update_commitment_sparse};
+pub use serialization::deserialize_update_commitment_sparse;
 
 use banderwagon::Element;
 use banderwagon::Fr;

--- a/ffi_interface/src/serialization.rs
+++ b/ffi_interface/src/serialization.rs
@@ -63,12 +63,6 @@ pub fn deserialize_update_commitment_sparse(
     Ok((commitment_bytes, indexes, old_scalars, new_scalars))
 }
 
-/// This is kept so that commitRoot in the java implementation can be swapped out
-/// Note: I believe we should not need to expose this method.
-pub fn deprecated_serialize_commitment(commitment: CommitmentBytes) -> [u8; 32] {
-    Element::from_bytes_unchecked_uncompressed(commitment).to_bytes()
-}
-
 #[must_use]
 pub(crate) fn deserialize_proof_query(bytes: &[u8]) -> ProverQuery {
     // Commitment

--- a/verkle-trie/tests/golang_interop.rs
+++ b/verkle-trie/tests/golang_interop.rs
@@ -60,9 +60,9 @@ fn golang_rust_interop() {
 
     trie.insert(key_vals);
 
-    let root = trie.root_commitment();
+    let root = trie.root_hash();
 
-    let expected = "10ed89d89047bb168baa4e69b8607e260049e928ddbcb2fdd23ea0f4182b1f8a";
+    let expected = "4caf7631af042c1615845a0116e789de0beea3e07f4b947377101aa822964614";
 
     use banderwagon::trait_defs::*;
     let mut root_bytes = [0u8; 32];


### PR DESCRIPTION
## Rationale 

TLDR: Imagine you were using a cryptography library which exposed two methods `hash1` and `hash2` where the difference between the two of them is that `hash1` uses keccak256 and `hash2` uses `sha256`. From the callers perspective you get a 32 byte slice regardless, so having both of these in the API does not add any extra functionality. We can therefore remove one.

The existence of `deprecated_serialize_commitment` on the API allows downstream users to serialize a commitment to a 32 byte array. `hash_commitment` holds the same functionality, with the exception that the 32 byte array represents a field element. From the perspective of the verkle trie library, these two methods provide the same functionality.

Having two ways to convert a commitment to a 32 byte array, where they are used in different places in the code allows for footguns and confusions especially when trying to decide which one to use. Using one in place of the other in the public API, makes it seem like one of them is more special than the other.

See #86 