### PR TITLE
Revert "chore!: Remove `deprecated_serialize_commitment` from API"

### DIFF
--- a/ffi_interface/src/lib.rs
+++ b/ffi_interface/src/lib.rs
@@ -2,8 +2,9 @@ mod serialization;
 
 // TODO: These are re-exported to not break the java code
 // TODO: we ideally don't want to export these.
+// - deprecated_serialize_commitment will be deprecated
 // - deserialize_update_commitment_sparse should not be exported and is an abstraction leak
-pub use serialization::deserialize_update_commitment_sparse;
+pub use serialization::{deprecated_serialize_commitment, deserialize_update_commitment_sparse};
 
 use banderwagon::Element;
 use banderwagon::Fr;

--- a/ffi_interface/src/serialization.rs
+++ b/ffi_interface/src/serialization.rs
@@ -63,6 +63,12 @@ pub fn deserialize_update_commitment_sparse(
     Ok((commitment_bytes, indexes, old_scalars, new_scalars))
 }
 
+/// This is kept so that commitRoot in the java implementation can be swapped out
+/// Note: I believe we should not need to expose this method.
+pub fn deprecated_serialize_commitment(commitment: CommitmentBytes) -> [u8; 32] {
+    Element::from_bytes_unchecked_uncompressed(commitment).to_bytes()
+}
+
 #[must_use]
 pub(crate) fn deserialize_proof_query(bytes: &[u8]) -> ProverQuery {
     // Commitment

--- a/verkle-trie/tests/golang_interop.rs
+++ b/verkle-trie/tests/golang_interop.rs
@@ -60,9 +60,9 @@ fn golang_rust_interop() {
 
     trie.insert(key_vals);
 
-    let root = trie.root_hash();
+    let root = trie.root_commitment();
 
-    let expected = "4caf7631af042c1615845a0116e789de0beea3e07f4b947377101aa822964614";
+    let expected = "10ed89d89047bb168baa4e69b8607e260049e928ddbcb2fdd23ea0f4182b1f8a";
 
     use banderwagon::trait_defs::*;
     let mut root_bytes = [0u8; 32];


### PR DESCRIPTION
Reverts crate-crypto/rust-verkle#85