### PR TITLE
feat: add `add_commitment` method

### DIFF
--- a/verkle-spec/src/lib.rs
+++ b/verkle-spec/src/lib.rs
@@ -34,6 +34,10 @@ pub trait Hasher {
     }
 }
 
+pub fn chunk64(bytes64: [u8; 64]) -> [u128; 5] {
+    crate::util::chunk64(bytes64)
+}
+
 // This is the default implementation for `pedersen_hash`
 // in the EIP. Since the EIP hashes 64 bytes (address32 + tree_index),
 // we just special case the method here to hash 64 bytes.


### PR DESCRIPTION
This adds a method which allows one to add commitments together.

This is needed so that we can cache the commitment to the address and then add it in to compute the slot key